### PR TITLE
Fix test code for cosmos-sdk-blocksync/status

### DIFF
--- a/plugins/cosmos-sdk-blocksync/status/status_test.go
+++ b/plugins/cosmos-sdk-blocksync/status/status_test.go
@@ -18,7 +18,7 @@ func TestCollector(t *testing.T) {
 	// Mock
 	mockStatus := rpcCosmos.Status{}
 	mockStatus.Result.SyncInfo.LatestBlockHeight = "123456"
-	mockStatus.Result.SyncInfo.CachingUp = false
+	mockStatus.Result.SyncInfo.CatchingUp = false
 
 	mockClient := mocks.Client{}
 	mockClient.On("GetStatus").Return(&mockStatus, nil)
@@ -46,7 +46,7 @@ func TestIgnoreDuplicate(t *testing.T) {
 	// Mock
 	mockStatus := rpcCosmos.Status{}
 	mockStatus.Result.SyncInfo.LatestBlockHeight = "123456"
-	mockStatus.Result.SyncInfo.CachingUp = false
+	mockStatus.Result.SyncInfo.CatchingUp = false
 
 	mockClient := mocks.Client{}
 	mockClient.On("GetStatus").Return(&mockStatus, nil)


### PR DESCRIPTION
```
vatz-plugin-cosmoshub # make test
go test ./...
ok  	github.com/dsrvlabs/vatz-plugin-cosmoshub/plugins/cosmos-sdk-blocksync	(cached)
?   	github.com/dsrvlabs/vatz-plugin-cosmoshub/plugins/cosmos-sdk-blocksync/mocks	[no test files]
ok  	github.com/dsrvlabs/vatz-plugin-cosmoshub/plugins/cosmos-sdk-blocksync/policy	(cached)
ok  	github.com/dsrvlabs/vatz-plugin-cosmoshub/plugins/cosmos-sdk-blocksync/status	(cached)
?   	github.com/dsrvlabs/vatz-plugin-cosmoshub/plugins/is_alived	[no test files]
?   	github.com/dsrvlabs/vatz-plugin-cosmoshub/plugins/peer_count	[no test files]
ok  	github.com/dsrvlabs/vatz-plugin-cosmoshub/rpc/cosmos	(cached)
?   	github.com/dsrvlabs/vatz-plugin-cosmoshub/rpc/cosmos/mocks	[no test files]
```